### PR TITLE
Quick pdde bug fix

### DIFF
--- a/00_PDDE_Checker.R
+++ b/00_PDDE_Checker.R
@@ -45,7 +45,7 @@ operatingEndMissing <- Enrollment %>%
   ) %>%
   ungroup() %>%
   left_join(Project %>% 
-              select(ProjectID, ProjectName, OrganizationName, OperatingEndDate), 
+              select(ProjectID, OrganizationName, OperatingEndDate), 
             by = "ProjectID") %>%
   filter(NumOpenEnrollments == 0 & 
            MostRecentEnrollment >= 


### PR DESCRIPTION
The code was error-ing out at the operatingEndMissing dataframe in the PDDE code, so I implemented a fix (just had to remove ProjectName, which in both the Enrollment data and the merged-on Project data, which caused the variable to take on a different name ProjectName.x and ProjectName.y)