### PR TITLE
fix upload progress display

### DIFF
--- a/global.R
+++ b/global.R
@@ -26,6 +26,7 @@ library(viridis)
 library(HMIS)
 library(glue)
 library(janitor)
+library(shinyjs)
 
 options(shiny.maxRequestSize = 200000000)
 

--- a/server.R
+++ b/server.R
@@ -71,6 +71,8 @@ function(input, output, session) {
       )
     } else { # if it is hashed, set imported_zip to 1 and start running scripts
       values$imported_zip <- 1
+      hide('imported_progress')
+      
       withProgress({
         setProgress(message = "Processing...", value = .15)
         setProgress(detail = "Reading your files..", value = .2)

--- a/ui.R
+++ b/ui.R
@@ -52,6 +52,7 @@ dashboardPage(
     tags$head(
       tags$link(rel = "stylesheet", type = "text/css", href = "custom.css")
     ),
+    useShinyjs(),
     tabItems(
     tabItem(
       tabName = "tabHome",

--- a/www/custom.css
+++ b/www/custom.css
@@ -176,8 +176,3 @@
   top:1em;
   right:1em;
 }
-
-/* || HIDE BUILT-IN UPLOAD COMPLETE BAR*/
-#imported_progress {
-  display:none;
-}


### PR DESCRIPTION
show built-in _upload_ progress bar, but then hide it when upload is complete. At that point, the custom _processing_ progress bar will kick in.