### PR TITLE
add a second summary tab, by Organization (if System-wide) or Project…

### DIFF
--- a/server.R
+++ b/server.R
@@ -538,12 +538,12 @@ function(input, output, session) {
       orgDQoverlaps <- overlaps %>%
         filter(OrganizationName %in% c(input$orgList) | PreviousOrganizationName %in% c(input$orgList))
       
-      getDQReportDataList(orgDQData, orgDQoverlaps)
+      getDQReportDataList(orgDQData, orgDQoverlaps, "ProjectName")
     })
     
     fullDQReportDataList <- reactive({
       req(valid_file() == 1)
-      getDQReportDataList(dq_main_reactive(), overlaps)
+      getDQReportDataList(dq_main_reactive(), overlaps, "OrganizationName")
     })
     
     output$downloadOrgDQReport <- downloadHandler(


### PR DESCRIPTION
Bringing back the original summary tab that goes by org (for system-wide) and project (for org-specific) exports.