### PR TITLE
Validating client count daterange

### DIFF
--- a/server.R
+++ b/server.R
@@ -220,6 +220,7 @@ function(input, output, session) {
       updateDateRangeInput(session = session, inputId = "dateRangeCount",
                            min = meta_HUDCSV_Export_Start,
                            start = meta_HUDCSV_Export_Start,
+                           max = meta_HUDCSV_Export_End,
                            end = meta_HUDCSV_Export_End)
     }
     

--- a/server.R
+++ b/server.R
@@ -360,6 +360,8 @@ function(input, output, session) {
       ReportStart <- input$dateRangeCount[1]
       ReportEnd <- input$dateRangeCount[2]
       
+      validate(need(ReportStart <= ReportEnd, "Please make sure date range is correct."))
+      
       datatable(
         validation %>%
           filter(served_between(., ReportStart, ReportEnd) &
@@ -423,6 +425,8 @@ function(input, output, session) {
       req(valid_file() == 1)
       ReportStart <- input$dateRangeCount[1]
       ReportEnd <- input$dateRangeCount[2]
+      
+      validate(need(ReportStart <= ReportEnd, "Please make sure date range is correct."))
       
       hhs <- validation %>%
         filter(served_between(., ReportStart, ReportEnd) &


### PR DESCRIPTION
added a max and also a validate() command to the client count boxes. The latter checks that start <= end.