### PR TITLE
validating incorrect df for the system-level warnings plot (fixed)

### DIFF
--- a/server.R
+++ b/server.R
@@ -794,7 +794,7 @@ function(input, output, session) {
     output$systemDQWarningsByOrg <- renderPlot({
       req(valid_file() == 1)
       
-      validate(need(nrow(dq_sys_lvl_general_errors_by_org) > 0, 
+      validate(need(nrow(dq_sys_lvl_warnings_by_org) > 0, 
                     message = "Great job! No warnings to show."))
       
       dq_sys_lvl_warnings_by_org_plot})


### PR DESCRIPTION
found in testing a smaller dataset- System-level warnings plot pointed to a row count of the incorrect data frame (fixed)