### PR TITLE
is_null originally came from the rlang package, a dependency of tidyv…

### DIFF
--- a/05_DataQuality.R
+++ b/05_DataQuality.R
@@ -815,7 +815,7 @@ rm(list = ls(pattern = "Top*"),
 
 # Project Exit Before Start --------------
 exit_before_start <- base_dq_data %>%
-  filter(ExitDate < EntryDate & !is_null(ExitDate) & !is_null(EntryDate)) %>% 
+  filter(ExitDate < EntryDate & !is.null(ExitDate) & !is.null(EntryDate)) %>% 
   mutate(Issue = "Project Exit Before Start",
          Type = "Error",
          Guidance = guidance_exit_before_start) %>%


### PR DESCRIPTION
…erse. But testthat also includes an is_null and this duality throws an error.