### PR TITLE
Fixed very minor typo

### DIFF
--- a/05_DataQuality_functions.R
+++ b/05_DataQuality_functions.R
@@ -285,7 +285,7 @@ renderDQPlot <- function(level, issueType, group, color) {
     req(valid_file() == 1)
   
     issueTypeDisplay = if_else(issueType == "High Priority", 
-                               "error", 
+                               "errors", 
                                paste0(tolower(issueType),"s")
                                )
     


### PR DESCRIPTION
In High Priority error charts when there are no High Priority errors to show. Originally read "no error to show" when it should have been "no errors to show."