### PR TITLE
correcting "invalid movein date" logic 

### DIFF
--- a/05_DataQuality.R
+++ b/05_DataQuality.R
@@ -1214,7 +1214,7 @@ dq_overlaps2 <- overlaps %>%
 invalid_movein_date <- base_dq_data %>%
   filter(ProjectType %in% ph_project_types & 
         (!is.na(MoveInDate) & MoveInDate < EntryDate) | 
-        (!is.na(MoveInDate) & MoveInDate > ExitAdjust)
+        (!is.na(MoveInDate) & !is.na(ExitDate) & MoveInDate > ExitDate)
   ) %>%
   merge_check_info(checkIDs = 40) %>%
   select(all_of(vars_we_want))


### PR DESCRIPTION
so it doesn't catch valid movein dates. Please disregard the name of the branch, it's incorrect; the title of the PR is correct.