### PR TITLE
make sure the FSA table is displayed after an upload. We hide it when…

### DIFF
--- a/changelog.R
+++ b/changelog.R
@@ -1,8 +1,8 @@
 output$changelog <- renderTable({
   tribble(
     ~Date, ~Change,
-    "05-02-2024", "Added demo mode, where users can try out Eva even if they
-    don't have access to an FY 2024 HMIS CSV Export",
+    "05-20-2024", "Added demo mode, where users can try out Eva even if they
+    don't have access to an FY 2024 HMIS CSV Export.",
     
     "04-09-2024", "Moved all variables from global environment to a session 
     environment to ensure appropriate visibility.",

--- a/demo_management.R
+++ b/demo_management.R
@@ -106,8 +106,6 @@ toggleDemoJs <- function(t) {
     shinyjs::hide(id = "successful_upload")
     shinyjs::disable("imported")
     
-    shinyjs::show('fileStructureAnalysis')
-    
     print("Switched to demo mode!")
     logMetadata("Switched to demo mode")
     
@@ -115,7 +113,6 @@ toggleDemoJs <- function(t) {
     capture.output("Switching to live mode")
     
     updateTabItems(session, "sidebarmenuid", "tabUpload")
-    shinyjs::hide('fileStructureAnalysis')
     
     shinyjs::runjs("
           $('#imported').closest('.btn').removeAttr('disabled');

--- a/server.R
+++ b/server.R
@@ -215,6 +215,8 @@ function(input, output, session) {
               "))
             }
             
+            shinyjs::show('fileStructureAnalysis')
+            
             updatePickerInput(session = session, inputId = "currentProviderList",
                               choices = sort(Project$ProjectName))
             

--- a/server.R
+++ b/server.R
@@ -215,8 +215,6 @@ function(input, output, session) {
               "))
             }
             
-            shinyjs::show('fileStructureAnalysis')
-            
             updatePickerInput(session = session, inputId = "currentProviderList",
                               choices = sort(Project$ProjectName))
             
@@ -256,7 +254,7 @@ function(input, output, session) {
   
   # File Structure Analysis Summary -----------------------------------------
   # update_fsa <- function() {
-  output$fileStructureAnalysis <- DT::renderDataTable({
+  output$fileStructureAnalysis <- renderDT({
     req(nrow(file_structure_analysis_main()))
     req(initially_valid_import() == 1)
     a <- file_structure_analysis_main() %>%
@@ -500,7 +498,7 @@ function(input, output, session) {
   })
   
   # CLIENT COUNT DETAILS - APP ----------------------------------------------
-  output$clientCountData <- DT::renderDataTable({
+  output$clientCountData <- renderDT({
     req(valid_file() == 1)
     req(nrow(validation()) > 0)
     
@@ -522,7 +520,7 @@ function(input, output, session) {
   
   # CLIENT COUNT SUMMARY - APP ----------------------------------------------
   
-  output$clientCountSummary <- DT::renderDataTable({
+  output$clientCountSummary <- renderDT({
     req(valid_file() == 1)
     
     exportTestValues(clientCountSummary = client_count_summary_df())
@@ -591,7 +589,7 @@ function(input, output, session) {
   )
   
   # summary table
-  output$pdde_summary_table <- DT::renderDataTable({
+  output$pdde_summary_table <- renderDT({
     req(valid_file() == 1)
     
     a <- pdde_main() %>%
@@ -612,7 +610,7 @@ function(input, output, session) {
   
   # PDDE Guidance -----------------------------------------------------------
   
-  output$pdde_guidance_summary <- DT::renderDataTable({
+  output$pdde_guidance_summary <- renderDT({
     req(valid_file() == 1)
     
     guidance <- pdde_main() %>%
@@ -635,7 +633,7 @@ function(input, output, session) {
   # DQ Org Summary -------------------------------------------------------
   source("05_DataQuality_functions.R", local = TRUE)
   
-  output$dq_organization_summary_table <- DT::renderDataTable({
+  output$dq_organization_summary_table <- renderDT({
     req(valid_file() == 1)
     
     a <- dq_main_reactive() %>%
@@ -666,7 +664,7 @@ function(input, output, session) {
   
   # DQ Org Guidance -------------------------------------------------------
   
-  output$dq_org_guidance_summary <- DT::renderDataTable({
+  output$dq_org_guidance_summary <- renderDT({
     req(valid_file() == 1)
     
     guidance <- dq_main_reactive() %>%
@@ -905,7 +903,7 @@ function(input, output, session) {
   # 
   # output$utilizationNote <- renderUI(HTML(note_calculation_utilization))
   # 
-  # output$utilizationDetail <- DT::renderDataTable({
+  # output$utilizationDetail <- renderDT({
   #   ReportStart <-
   #     floor_date(ymd(input$utilizationDate),
   #                unit = "month")

--- a/ui.R
+++ b/ui.R
@@ -332,7 +332,7 @@ dashboardPage(
           fluidRow(box(
             title = "HMIS CSV Export File Structure Analysis",
             width = 12,
-            DT::dataTableOutput("fileStructureAnalysis"),
+            DTOutput("fileStructureAnalysis"),
             p(),
             HTML("<p>Users should contact their vendor to resolve high priority 
             errors identified in the HMIS CSV Export File Structure Analysis, as
@@ -632,14 +632,14 @@ dashboardPage(
           title = "Client Counts Summary",
           status = "info",
           solidHeader = TRUE,
-          DT::dataTableOutput("clientCountSummary"),
+          DTOutput("clientCountSummary"),
           width = 12
         )),
         fluidRow(box(
           title = "Client Counts Detail",
           status = "info",
           solidHeader = TRUE,
-          DT::dataTableOutput("clientCountData"),
+          DTOutput("clientCountData"),
           width = 12
         ))
       ),
@@ -670,13 +670,13 @@ dashboardPage(
             title = paste("PDDE Check Summary"),
             status = "info",
             solidHeader = TRUE,
-            DT::dataTableOutput("pdde_summary_table"),
+            DTOutput("pdde_summary_table"),
             width = 12,
             br(),
             uiOutput("downloadPDDEReportButton") %>% withSpinner()
           ),
           box(id = "PDDEGuidance",
-              DT::dataTableOutput("pdde_guidance_summary"),
+              DTOutput("pdde_guidance_summary"),
               title = "Guidance",
               width = 12,
               status = "info",
@@ -821,7 +821,7 @@ dashboardPage(
             title = paste("Data Quality Summary"),
             status = "info",
             solidHeader = TRUE,
-            DT::dataTableOutput("dq_organization_summary_table"),
+            DTOutput("dq_organization_summary_table"),
             width = 12
           )
         ),
@@ -829,7 +829,7 @@ dashboardPage(
         fluidRow(
           box(
             id = "DQSummaryProvider",
-            DT::dataTableOutput("dq_org_guidance_summary"),
+            DTOutput("dq_org_guidance_summary"),
             title = "Data Quality Guidance",
             width = 12,
             status = "info",


### PR DESCRIPTION
… demo mode is turned off so as not to leave a big blank space there. However, this means that even while the underlying data may update after an upload, the FSA table won't display. This ensures it does