### PR TITLE
Make use of waterfall chart data

### DIFF
--- a/09_sankey_chart.R
+++ b/09_sankey_chart.R
@@ -4,13 +4,11 @@ plot_data <- reactive({
   plot_df <- sys_df_universe() %>%
     filter(InflowTypeDetail == "Housed" | InflowTypeDetail == "Homeless") %>%
     group_by(PersonalID) %>%
-    mutate(
-      lastExit = max(ExitAdjust) == ExitAdjust
-    ) %>%
-    filter(max(lastExit) == lastExit) %>%
+    filter(max(ExitAdjust) == ExitAdjust) %>%
     ungroup() %>%
-    select(PersonalID, InflowTypeDetail, OutflowTypeDetail, lastExit, ExitAdjust, Destination) %>%
+    select(PersonalID, InflowTypeDetail, OutflowTypeDetail, Destination, EnrollmentID, ExitAdjust) %>%
     unique()
+    
   # if any enrollments share the same exit date, dedup them using the following logic
     # 1. take permanent over temp over other
     # 2. within a destination type (perm, temp, oother) take the lower destination value
@@ -49,11 +47,9 @@ plot_data <- reactive({
       "Type" = case_when(
         OutflowTypeDetail == "Housed" ~ "Enrolled, Housed",
         OutflowTypeDetail == "Homeless" ~ "Enrolled, Homeless",
-        lastExit == TRUE & 
-          Destination %in% perm_livingsituation &
+        Destination %in% perm_livingsituation &
           ExitAdjust <= ReportEnd() ~ "Exited, Permanent",
-        lastExit == TRUE & 
-          !(Destination %in% perm_livingsituation) &
+        !(Destination %in% perm_livingsituation) &
           ExitAdjust <= ReportEnd() ~ "Exited, Non-Permanent",
         TRUE ~ OutflowTypeDetail
       )

--- a/09_sankey_chart.R
+++ b/09_sankey_chart.R
@@ -1,61 +1,17 @@
 # The universe is anyone who was Housed or Homeless at Period Start
 # We also need the latest exit for the folks in the Exited categories
 plot_data <- reactive({
-  plot_df <- sys_df_universe() %>%
+  
+  plot_df <- sys_inflow_outflow_plot_data() %>%
     filter(InflowTypeDetail == "Housed" | InflowTypeDetail == "Homeless") %>%
-    group_by(PersonalID) %>%
-    filter(max(ExitAdjust) == ExitAdjust) %>%
-    ungroup() %>%
-    select(PersonalID, InflowTypeDetail, OutflowTypeDetail, Destination, EnrollmentID, ExitAdjust) %>%
-    unique()
-    
-  # if any enrollments share the same exit date, dedup them using the following logic
-    # 1. take permanent over temp over other
-    # 2. within a destination type (perm, temp, oother) take the lower destination value
-    # 3. within the same destination number, take the highest enrollment ID
-  if(any(duplicated(plot_df$PersonalID))) {
-    destination_categories <- c("Permanent" = 1, "Temp" = 2, "Other" = 3)
-    plot_df <- plot_df %>%
-      group_by(PersonalID) %>%
-      mutate(
-        DestinationCategory = factor(
-          case_when(
-            Destination %in% perm_livingsituation ~ 1,
-            Destination %in% c(
-              temp_livingsituation,
-              institutional_livingsituation,
-              homeless_livingsituation_incl_TH
-            ) ~ 2,
-            TRUE ~ 3
-          ), 
-          levels = destination_categories,
-          labels = names(destination_categories)
-        )
-      ) %>%
-      arrange(DestinationCategory, Destination, desc(EnrollmentID)) %>%
-      slice(1) %>%
-      ungroup()
-  }
 
   startBind <- plot_df %>%
     select(PersonalID, "Type" = InflowTypeDetail) %>%
     mutate("Period" = "Begin")
   
   endBind <- plot_df %>%
-    mutate(
-      "Period" = "End",
-      "Type" = case_when(
-        OutflowTypeDetail == "Housed" ~ "Enrolled, Housed",
-        OutflowTypeDetail == "Homeless" ~ "Enrolled, Homeless",
-        Destination %in% perm_livingsituation &
-          ExitAdjust <= ReportEnd() ~ "Exited, Permanent",
-        !(Destination %in% perm_livingsituation) &
-          ExitAdjust <= ReportEnd() ~ "Exited, Non-Permanent",
-        TRUE ~ OutflowTypeDetail
-      )
-    ) %>%
-    select(PersonalID, Period, Type)
-  
+    select(PersonalID, "Type" = OutflowTypeDetail) %>%
+    mutate("Period" = "End")
     
   allBind <- rbind(startBind, endBind)
   

--- a/09_sankey_chart.R
+++ b/09_sankey_chart.R
@@ -1,6 +1,6 @@
 # The universe is anyone who was Housed or Homeless at Period Start
 # We also need the latest exit for the folks in the Exited categories
-plot_data <- reactive({
+sankey_plot_df <- reactive({
   
   plot_df <- sys_inflow_outflow_plot_data() %>%
     filter(InflowTypeDetail == "Housed" | InflowTypeDetail == "Homeless") %>%

--- a/server.R
+++ b/server.R
@@ -23,7 +23,6 @@ function(input, output, session) {
     sys_df_people_universe_filtered_r <- reactiveVal(),
     ReportStart <- reactiveVal(),
     ReportEnd <- reactiveVal(),
-    sys_df_universe <- reactiveVal(),
     sankey_plot_data <- reactiveVal(),
     non_ascii_files_detail_df <- reactiveVal(),
     non_ascii_files_detail_r <- reactiveVal()
@@ -209,10 +208,9 @@ function(input, output, session) {
             input$syso_gender
             input$syso_race_ethnicity
           }, {
-            sys_df_universe(universe_ppl_flags())
             sys_inflow_outflow_plot_data(inflow_outflow_df())
             sys_df_people_universe_filtered_r(clients_enrollments_reactive())
-            sankey_plot_data(plot_data())
+            sankey_plot_data(sankey_plot_df())
           })
           
           setProgress(detail = "Done!", value = 1)


### PR DESCRIPTION
Instead of handling tie breakers here, we decided that the sankey logic should mimic the waterfall logic, both for Active at Start categories, Active at End, and tie-breaking Exited, Permanent/Non-Permanent