### PR TITLE
fixed bug in Hh_no_hoh check

### DIFF
--- a/05_DataQuality.R
+++ b/05_DataQuality.R
@@ -248,7 +248,9 @@ hh_no_hoh_dt <- hh_no_hoh_dt[hasHoH == FALSE]
 
 hh_no_hoh <- as.data.frame.matrix(
   base_dq_data_dt[hh_no_hoh_dt, on = .(PersonalID, HouseholdID)]
-)
+) %>% 
+  merge_check_info(checkIDs = 2) %>%
+  select(all_of(vars_we_want))
 
 
 hh_too_many_hohs <- base_dq_data %>%


### PR DESCRIPTION
hh_no_hoh in the performance-improvements branch, didn't have only the right columns selected. Our other datasets don't have this issue, so it wasn't crashing. But one of our test datasets does have the issue, and that crashed Eva.