### PR TITLE
A couple 508 fixes plus text changes

### DIFF
--- a/07_system_overview.R
+++ b/07_system_overview.R
@@ -1096,7 +1096,7 @@ universe_ppl_flags <- reactive({
         active_at_start_housed_client == TRUE ~ "Housed",
         return_from_perm_client == TRUE ~ "Returned from \nPermanent",
         reengaged_from_temp_client == TRUE ~ "Re-engaged from \nNon-Permanent",
-        newly_homeless_client == TRUE ~ "Newly Homeless",
+        newly_homeless_client == TRUE ~ "First Time \nHomeless",
         TRUE ~ "something's wrong"
       ),
       

--- a/glossary.R
+++ b/glossary.R
@@ -167,15 +167,9 @@ output$glossary <- renderDataTable({
     to filter by.",
     
     "System Performance Filters",
-    "Special Populations",
-    "A single-select demographic filter. Eva allows users to filter system performance 
-    by special populations. A special population is a group of people that share 
-    a demographic or system utilization characteristic.",
-    
-    "System Performance Filters",
-    "All Populations",
-    "A Special Populations selection that includes all clients regardless of whether 
-    they are identified as being part of a special population.",
+    "All Statuses",
+    "A Veteran Status selection that includes all clients, including children, 
+    regardless of their Veteran Status.",
     
     "System Performance Filters",
     "Veteran Status",

--- a/glossary.R
+++ b/glossary.R
@@ -428,7 +428,7 @@ output$glossary <- renderDataTable({
     "The number of clients that entered or flowed into the system. This status indicates a client entered a system project after the report period’s start date. This status excludes all clients who were counted as homeless or housed at the start of the report period.",
     
     "System Flow Chart",
-    "Newly Homeless",
+    "First Time Homeless",
     "This inflow system status indicates a client who entered the system after the report period’s start date and who also had not been served in the system within the 24 months prior to their entry into the report period. This inflow system status is only available when a dataset with 36 months of data is uploaded to Eva.",
     
     "System Flow Chart",
@@ -441,7 +441,7 @@ output$glossary <- renderDataTable({
     
     "System Flow Chart",
     "Inflow Unspecified",
-    "This system status indicates a client who entered the system after the report start date, but it cannot be determined if they are newly homeless because there is not enough lookback data. This inflow system status takes the place of Newly Homeless in cases where less than 36 months of data are uploaded to Eva.",
+    "This system status indicates a client who entered the system after the report start date, but it cannot be determined if they are newly homeless because there is not enough lookback data. This inflow system status takes the place of First Time Homeless in cases where less than 36 months of data are uploaded to Eva.",
     
     "System Flow Chart",
     "Outflow",

--- a/hardcodes.R
+++ b/hardcodes.R
@@ -137,7 +137,7 @@ syso_hh_types <- list(
   "Adult Only" = "AO",
   "- Adult Only 18-24" = "UY",
   "Adult Child" = "AC",
-  "- Parenting Youth" = "PY",
+  "- Parenting Young Adult" = "PY",
   "Child Only" = "CO"
 )
 

--- a/hardcodes.R
+++ b/hardcodes.R
@@ -135,6 +135,7 @@ syso_hh_types <- list(
   "All Household Types" = "All",
   "- Youth and Young Adult" = "YYA",
   "Adult Only" = "AO",
+  "- Adult Only 18-24" = "UY",
   "Adult Child" = "AC",
   "- Parenting Youth" = "PY",
   "Child Only" = "CO"

--- a/hardcodes.R
+++ b/hardcodes.R
@@ -277,7 +277,7 @@ syso_chronic_pops <- list(
 )
 
 syso_spec_pops_people <- c(
-  "All Populations" = "None",
+  "All Statuses" = "None",
   # "Inflow",
   syso_veteran_pops#,
   #syso_dv_pops,

--- a/system_composition_server.R
+++ b/system_composition_server.R
@@ -25,11 +25,10 @@ syscomp_detailBox <- function(session) {
       if (input$syso_project_type != "All")
         chart_selection_detail_line("Project Type Group", syso_project_types, input$syso_project_type),
       
-      chart_selection_detail_line(
-        "Methodology Type",
-        syso_methodology_types,
-        input$methodology_type
-      ),
+      #detail_line for "Methodology Type" where only the first part of the label before the : is pulled in
+      HTML(glue(
+        "<b>Methodology Type:</b> {str_sub(getNameByValue(syso_methodology_types, input$methodology_type), start = 1, end = 19)} <br>"
+      )),
       
       HTML(
         glue(

--- a/system_inflow_outflow_server.R
+++ b/system_inflow_outflow_server.R
@@ -7,7 +7,7 @@ frame_detail <-
     Status = c(
       "Housed",
       "Homeless",
-      "Newly Homeless",
+      "First Time \nHomeless",
       "Returned from \nPermanent",
       "Re-engaged from \nNon-Permanent",
       "Exited,\nPermanent",
@@ -18,7 +18,7 @@ frame_detail <-
     ),
     Time = c(
       rep("Active at Start", 2),
-      "Newly Homeless",
+      "First Time \nHomeless",
       "Returned from \nPermanent",
       "Re-engaged from \nNon-Permanent",
       "Exited,\nPermanent",
@@ -87,7 +87,7 @@ system_activity_prep_detail <- reactive({
       Time = factor(
         Time,
         levels = c("Active at Start",
-                   "Newly Homeless",
+                   "First Time \nHomeless",
                    "Returned from \nPermanent",
                    "Re-engaged from \nNon-Permanent",
                    "Exited,\nNon-Permanent",
@@ -100,7 +100,7 @@ system_activity_prep_detail <- reactive({
         levels = c(
           "Housed",
           "Homeless",                          
-          "Newly Homeless",
+          "First Time \nHomeless",
           "Returned from \nPermanent",
           "Re-engaged from \nNon-Permanent",
           "Exited,\nNon-Permanent",
@@ -330,7 +330,7 @@ sys_inflow_outflow_export_info <- function(df) {
   )
 }
 output$sys_inflow_outflow_download_btn <- downloadHandler(
-  filename = date_stamped_filename("System Inflow/Outflow Report - "),
+  filename = date_stamped_filename("System Flow Report - "),
   content = function(file) {
     df <- system_activity_prep_detail() %>% 
       select(Status, values, Time, InflowOutflow, InflowOutflowSummary)
@@ -341,7 +341,7 @@ output$sys_inflow_outflow_download_btn <- downloadHandler(
           bind_rows(sys_export_filter_selections()) %>%
           bind_rows(sys_inflow_outflow_export_info(df)) %>%
           mutate(Value = replace_na(Value, 0)) %>%
-          rename("System Inflow/Outflow" = Value),
+          rename("System Flow" = Value),
         "System Flow Data" = bind_rows(
           df, df %>% 
             group_by(InflowOutflowSummary) %>% 

--- a/system_inflow_outflow_server.R
+++ b/system_inflow_outflow_server.R
@@ -250,7 +250,7 @@ get_system_inflow_outflow_plot <- function(id) {
       size = 16 / .pt,
       label = paste0(
         sys_total_count_display(total_clients),
-        "\nTotal Change: ",
+        "Total Change: ",
         case_when(
           inflow_to_outflow > 0 ~ paste0("+", scales::comma(inflow_to_outflow)),
           inflow_to_outflow == 0 ~ "0",
@@ -379,12 +379,12 @@ output$sys_inflow_outflow_download_btn_ppt <- downloadHandler(
     
     sys_overview_ppt_export(
       file = file,
-      title_slide_title = "System Inflow/Outflow",
+      title_slide_title = "System Flow",
       summary_items = sys_export_summary_initial_df() %>%
         filter(Chart != "Start Date" & Chart != "End Date") %>% 
         bind_rows(sys_export_filter_selections()) %>%
         bind_rows(sys_inflow_outflow_export_info(df)),
-      plot_slide_title = "System Inflow/Outflow summary",
+      plot_slide_title = "System Flow Summary",
       plot1 = get_system_inflow_outflow_plot("sys_act_summary_ui_chart"),
       plot2 = get_system_inflow_outflow_plot("sys_act_detail_ui_chart"),
       summary_font_size = 19

--- a/system_overview_server.R
+++ b/system_overview_server.R
@@ -97,8 +97,10 @@ syso_detailBox <- reactive({
     if (selected_race != "All Races/Ethnicities")
       race_ethnicity_line,
     
-    if(getNameByValue(syso_spec_pops_people, input$syso_spec_pops) != "None")
-      detail_line("Veteran Status", syso_spec_pops_people, input$syso_spec_pops)
+    if(getNameByValue(syso_spec_pops_people, input$syso_spec_pops) != "All Statuses")
+      HTML(glue(
+        "<b>Veteran Status:</b> {paste(getNameByValue(syso_spec_pops_people, input$syso_spec_pops), '(Adult Only)')} <br>"
+      ))
     
   )
 })

--- a/system_overview_server.R
+++ b/system_overview_server.R
@@ -116,7 +116,7 @@ toggle_sys_components <- function(cond, init=FALSE) {
   # 2. toggles subtabs and download button based if valid file has been uploaded
   # 3. moves download button to be in line with subtabs
   tabs <- c(
-    "System Inflow/Outflow" = "inflow_outflow",
+    "System Flow" = "inflow_outflow",
     "Client System Status" = "status",
     "System Demographics" = "comp"
   )

--- a/system_overview_server.R
+++ b/system_overview_server.R
@@ -81,10 +81,10 @@ syso_detailBox <- reactive({
     
     format(ReportStart(), "%m-%d-%Y"), " to ", format(ReportEnd(), "%m-%d-%Y"), br(),
     
-    if (getNameByValue(syso_project_types, input$syso_project_type) != "All")
-      detail_line("Project Type", syso_project_types, input$syso_project_type),
-    
-    detail_line("Methodology Type", syso_methodology_types, input$methodology_type),
+    #detail_line for "Methodology Type" where only the first part of the label before the : is pulled in
+    HTML(glue(
+      "<b>Methodology Type:</b> {str_sub(getNameByValue(syso_methodology_types, input$methodology_type), start = 1, end = 19)} <br>"
+    )),
     
     if (length(input$syso_age) != length(syso_age_cats))
       HTML(glue(
@@ -98,7 +98,7 @@ syso_detailBox <- reactive({
       race_ethnicity_line,
     
     if(getNameByValue(syso_spec_pops_people, input$syso_spec_pops) != "None")
-      detail_line("Special Populations", syso_spec_pops_people, input$syso_spec_pops)
+      detail_line("Veteran Status", syso_spec_pops_people, input$syso_spec_pops)
     
   )
 })

--- a/ui.R
+++ b/ui.R
@@ -1209,17 +1209,18 @@ dashboardPage(
                                     <td>In the Detail chart, the bar for “Inactive”
                                     is larger than the bar for “Permanent 
                                     Destination” and the bar for “Non-Permanent Destination.”</td>
-                                    <td>This means many clients ended the period 
-                                    in an open enrollment without a recent Current 
-                                    Living Situation (CLS) record, and thus were 
-                                    counted as leaving your homeless system. 
-                                    Since it is not possible to accurately determine 
-                                    if they are still experiencing homelessness, 
-                                    clients without recent CLS records are presumed 
-                                    to have exited. Check that clients enrolled 
-                                    in Street Outreach, Coordinated Entry, Day Shelter, 
-                                    Supportive Services, and Other project type 
-                                    enrollments have CLS records entered at each contact.</td>
+                                    <td>This means many ended the report period 
+                                    with (1) an open enrollment in an Emergency 
+                                    Shelter – Night-by-Night project that has not 
+                                    had a bed night recorded within the last 15 
+                                    days of the report period, (2) an open enrollment 
+                                    in Street Outreach, Day Shelter, Supportive 
+                                    Services, and Other project type enrollments 
+                                    without a Current Living Situation (CLS) record 
+                                    within the last 60 days of the report period, 
+                                    or (3) an open enrollment in Coordinated Entry 
+                                    without a CLS record within the last 90 days 
+                                    of the report period.</td>
                                   </tr>
                                 </table>")
                   )
@@ -1317,17 +1318,18 @@ dashboardPage(
                                     Period Start are inactive at Period End</td>
                                     <td>The category “Inactive” is display in the 
                                     chart at Period End.</td>
-                                    <td>This means some clients ended the period 
-                                    in an open enrollment without a recent Current 
-                                    Living Situation (CLS) record, and thus were 
-                                    counted as leaving your homeless system. Since 
-                                    it is not possible to accurately determine if 
-                                    they are still experiencing homelessness, clients 
-                                    without recent CLS records are presumed to have 
-                                    exited. Check that clients enrolled in Street 
-                                    Outreach, Coordinated Entry, Day Shelter, Supportive 
+                                    <td>This means some clients ended the report 
+                                    period with (1) an open enrollment in an Emergency 
+                                    Shelter – Night-by-Night project that has not 
+                                    had a bed night recorded within the last 15 
+                                    days of the report period, (2) an open enrollment 
+                                    in Street Outreach, Day Shelter, Supportive 
                                     Services, and Other project type enrollments 
-                                    have CLS records entered at each contact.</td>
+                                    without a Current Living Situation (CLS) record 
+                                    within the last 60 days of the report period, 
+                                    or (3) an open enrollment in Coordinated Entry 
+                                    without a CLS record within the last 90 days 
+                                    of the report period.</td>
                                   </tr>
                                 </table>")
                   )

--- a/ui.R
+++ b/ui.R
@@ -1109,7 +1109,7 @@ dashboardPage(
                                 
                                 <ul>
                                   <li><b>Inflow</b> is categorized into three groups: 
-                                  “Newly Homeless,” “Returned from Permanent,” and 
+                                  “First Time Homeless,” “Returned from Permanent,” and 
                                   “Re-engaged from Non-Permanent.”</li>
                                   <li><b>Outflow</b> is divided into three categories: 
                                   “Exited, Non-Permanent,” “Exited, Non-Permanent 
@@ -1177,7 +1177,7 @@ dashboardPage(
                                     in prior years, or if the change is because 
                                     fewer clients are exiting. Use the Detail Chart 
                                     to explore if a majority of the clients flowing 
-                                    in were newly homeless, returning to homelessness 
+                                    in were first time homeless, returning to homelessness 
                                     after previously exiting to a permanent destination, 
                                     or re-engaging with the system after previously 
                                     exiting to a non-permanent destination.</td>

--- a/ui.R
+++ b/ui.R
@@ -3,6 +3,7 @@ dashboardPage(
   skin = "black",
   dashboardHeader(
     title = span(img(src = "Eva_logo_horizontal_white.png",
+                     alt = "Eva logo",
                                    height = 45)),
     # https://alvarotrigo.com/blog/toggle-switch-css/
     tags$li(class="dropdown",

--- a/www/custom.css
+++ b/www/custom.css
@@ -47,6 +47,12 @@
     background: white;
 }
 
+/* toggle button focus */
+.skin-black .main-header .navbar .sidebar-toggle:focus {
+    color: #16697A; /*icon color - dark blue*/
+    background: white;
+}
+
 /* || MAIN SIDEBAR */
 
 /*sidebar color*/
@@ -66,7 +72,15 @@
 }
 
 /*sidebar color when menu option with a submenu is selected*/
-.skin-black .sidebar-menu>li.active>a, .skin-black .sidebar-menu>li:hover>a {
+.skin-black .sidebar-menu>li.active>a, 
+.skin-black .sidebar-menu>li:hover>a
+{
+    color: black; /*text color*/
+    background: #D0E7EC; /*sky*/
+    border-left-color: white;
+}
+
+.a:focus {
     color: black; /*text color*/
     background: #D0E7EC; /*sky*/
     border-left-color: white;
@@ -155,8 +169,8 @@
   border-color: #C2462E; /*coral*/
 }
 
-/*button hover*/
-.btn:hover {
+/*button hover and focus*/
+.btn:hover, .btn:focus {
   color: #C2462E; /*text color - coral*/
   background-color: white;
   border-color: #C2462E; /*text color - coral*/


### PR DESCRIPTION
- Added alt text to Eva logo
- Updated CSS focus color contrast for buttons so that contrast is 508 compliant when tabbing over buttons using keyboard
- Updated HH Type dropdown menu to include AO 18-24
- Updated Parenting Youth HH Type label
- Updated "Newly Homeless" to "First Time Homeless"
- Updated subheaders in chart detail box
  - Shortened "Methodology Type" line
  - Changed "Special Populations" line to "Veteran Statuses"
- Updated export download name from "System Inflow/Outflow" to "System Flow"
- Updated ppt slide titles to reference "System Flow"
- Removed line break/space between the "Total People" and "Total Change" lines on the waterfall chart