### PR TITLE
Phase 2 Metadata Capture for System Overview

### DIFF
--- a/helper_functions.R
+++ b/helper_functions.R
@@ -257,7 +257,8 @@ logSessionData <- function() {
     SourceContactFirst = Export()$SourceContactFirst,
     SourceContactLast = Export()$SourceContactLast,
     SourceContactEmail = Export()$SourceContactEmail,
-    SoftwareName = Export()$SoftwareName
+    SoftwareName = Export()$SoftwareName,
+    ImplementationID = Export()$ImplementationID
   )
   
   # put the export info in the log

--- a/system_overview_server.R
+++ b/system_overview_server.R
@@ -9,7 +9,7 @@ observeEvent(input$syso_tabbox, {
     condition = input$syso_tabbox == "Composition of All Served",
     class = "filter-hidden"
   )
-}, ignoreNULL = TRUE)
+}, ignoreNULL = TRUE) #need to add ignore init?
 
 observeEvent(input$methodology_type, {
   
@@ -204,6 +204,8 @@ font_size <- 14 / .pt
 
 # PowerPoint Export -------------------------------------------------------
 sys_overview_ppt_export <- function(file, title_slide_title, summary_items, plot_slide_title, plot1, plot2 = NULL, summary_font_size) {
+  logMetadata("downloaded system overview powerpoint") #NEED TO FIX - if want to get more granular, need to detect with title slide
+  
   report_period <- paste0("Report Period: ", 
                           format(meta_HUDCSV_Export_Start(), "%m/%d/%Y"),
                           " - ",

--- a/system_overview_server.R
+++ b/system_overview_server.R
@@ -4,12 +4,36 @@
 # move chart download button to be inline with subtabs
 observeEvent(input$syso_tabbox, {
   req(valid_file() == 1)
+  logMetadata(paste0("Clicked on: ", input$syso_tabbox,
+                     if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))
   toggleClass(
     id = "syso_inflowoutflow_filters",
     condition = input$syso_tabbox == "Composition of All Served",
     class = "filter-hidden"
   )
-}, ignoreNULL = TRUE) #need to add ignore init?
+}, ignoreNULL = TRUE, ignoreInit = TRUE) #confirm if need to have ignore init?
+
+
+observeEvent(input$sys_inflow_outflow_subtabs, {
+  req(valid_file() == 1)
+  logMetadata(paste0("Clicked on: ", input$sys_inflow_outflow_subtabs,
+                     if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))
+}, ignoreNULL = TRUE, ignoreInit = TRUE)
+
+
+observeEvent(input$sys_status_subtabs, {
+  req(valid_file() == 1)
+  logMetadata(paste0("Clicked on: ", input$sys_status_subtabs,
+                     if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))
+}, ignoreNULL = TRUE, ignoreInit = TRUE)
+
+
+observeEvent(input$sys_comp_subtabs, {
+  req(valid_file() == 1)
+  logMetadata(paste0("Clicked on: ", input$sys_comp_subtabs,
+                     if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))
+}, ignoreNULL = TRUE, ignoreInit = TRUE)
+
 
 observeEvent(input$methodology_type, {
   
@@ -143,6 +167,10 @@ toggle_sys_components <- function(cond, init=FALSE) {
 toggle_sys_components(FALSE, init=TRUE) # initially hide them
 
 sys_export_summary_initial_df <- function() {
+  
+  logMetadata(paste0("Downloaded System Overview Tabular Data",
+                     if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))
+  
   return(data.frame(
     Chart = c(
       "Start Date",
@@ -204,7 +232,9 @@ font_size <- 14 / .pt
 
 # PowerPoint Export -------------------------------------------------------
 sys_overview_ppt_export <- function(file, title_slide_title, summary_items, plot_slide_title, plot1, plot2 = NULL, summary_font_size) {
-  logMetadata("downloaded system overview powerpoint") #NEED TO FIX - if want to get more granular, need to detect with title slide
+  
+  logMetadata(paste0("Downloaded System Overview Powerpoint",
+                     if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", ""))) #NEED TO UPDATE - if want to get more granular, need to detect with title slide
   
   report_period <- paste0("Report Period: ", 
                           format(meta_HUDCSV_Export_Start(), "%m/%d/%Y"),


### PR DESCRIPTION
The following metadata will pull into the current metadata report:

- High Priority. Usage statistics: weekly and monthly primary and secondary horizontal tab hits
- High Priority. Weekly and monthly System Overview downloads 
  - High Priority. By total
  - Lower Priority. By chart (more like a nice-to-have if things get gnarly)
    - Break out by download type (image vs tabular)
- High Priority. Demo mode stats (primary and secondary horizontal tabs visited last 6 months, weekly downloads by chart)
- Low Priority. Count of inclusive versus exclusive methodology filter changes

All high priority items have been committed. Lower priority items will be added if time allows.