### PR TITLE
add logging of session end to console. we have it in metadata, but th…

### DIFF
--- a/server.R
+++ b/server.R
@@ -971,6 +971,7 @@ function(input, output, session) {
   source("system_status_server.R", local = TRUE)
   
   session$onSessionEnded(function() {
+    logToConsole("Session Ended")
     logMetadata("Session Ended")
   })
 }


### PR DESCRIPTION
…is may make it easier to see crashes in the logs