### PR TITLE
fix NbN vs. NbN overlap. Specificlaly, if there are too many duplicat…

### DIFF
--- a/05_DataQuality.R
+++ b/05_DataQuality.R
@@ -1224,30 +1224,17 @@ overlap_dt <- overlap_dt[IsOverlap == TRUE]
 # but because DatePRovided is m:1 with Enrollment, we need to process separately
 # from the enrollment-level data above
 if(nrow(Services) > 0) {
-  duplicate_dateprovided_by_person <- services_dt[
-    , DuplicateDateProvided := duplicated(DateProvided), 
+  overlap_nbns <- services_dt[, `:=`(
+      PreviousEnrollmentID = shift(EnrollmentID, type = "lag"),
+      IsOverlap = ifelse(duplicated(DateProvided) | duplicated(DateProvided, fromLast = TRUE), TRUE, FALSE), 
+      PreviousProjectType = es_nbn_project_type
+    ), 
     by = PersonalID
-  ][DuplicateDateProvided == TRUE][
-    , .(PersonalID, DateProvided)
+  ][
+    IsOverlap == TRUE,
+    .(PersonalID, EnrollmentID, PreviousEnrollmentID, DateProvided, IsOverlap, PreviousProjectType)
   ]
 
-  # Merge the duplicate dates back to Services to get EnrollmentIDs
-  overlap_nbns <- services_dt[
-    duplicate_dateprovided_by_person, 
-    on = .(PersonalID, DateProvided)
-  ][, `:=`(
-      EnrollmentID = EnrollmentID, 
-      PreviousEnrollmentID = shift(EnrollmentID, type = "lag")
-    ),
-    by = .(PersonalID, DateProvided)
-  ][
-    !is.na(PreviousEnrollmentID), 
-    .(PersonalID, EnrollmentID, PreviousEnrollmentID, DateProvided)
-  ][, `:=`(
-    IsOverlap = TRUE,
-    PreviousProjectType = es_nbn_project_type
-  )]
-  
   # add the NbN overlaps back onto the main overlap_Dt
   overlap_dt <- rbindlist(
     list(overlap_dt, overlap_nbns),


### PR DESCRIPTION
…es, we get a warning like: "Warning: Error in vecseq: Join results in 14 rows; more than 13 = nrow(x)+nrow(i)..." because the join was resulting in too many rows than the sum of both tables' rows.