### PR TITLE
Reference active inventory for pdde check

### DIFF
--- a/06_PDDE_Checker.R
+++ b/06_PDDE_Checker.R
@@ -450,7 +450,7 @@ overlapping_hmis_participation <- HMISParticipation %>%
 # Bed Type incompatible with Housing Type -----------------------------------
 # For ES projects, if HousingType is 1 or 2 (site-based), then BedType should be 1 (facility based beds). If HousingType is 3 (tenant-based), then BedType should be 2 (voucher beds).
 
-ES_BedType_HousingType <- Inventory %>%
+ES_BedType_HousingType <- activeInventory %>%
   left_join(Project0(), by = "ProjectID") %>%
   left_join(HousingTypeDF, by = "ProjectID") %>% 
   filter(ProjectType %in% c(es_ee_project_type, es_nbn_project_type) &

--- a/06_PDDE_Checker.R
+++ b/06_PDDE_Checker.R
@@ -451,7 +451,7 @@ overlapping_hmis_participation <- HMISParticipation %>%
 # For ES projects, if HousingType is 1 or 2 (site-based), then BedType should be 1 (facility based beds). If HousingType is 3 (tenant-based), then BedType should be 2 (voucher beds).
 
 ES_BedType_HousingType <- activeInventory %>%
-  left_join(Project0(), by = "ProjectID") %>%
+  left_join(Project0() %>% select(ProjectID, ProjectType), by = "ProjectID") %>%
   left_join(HousingTypeDF, by = "ProjectID") %>% 
   filter(ProjectType %in% c(es_ee_project_type, es_nbn_project_type) &
            ((HousingType %in% c(client_single_site, client_multiple_sites) & ESBedType!=1) | (HousingType==tenant_scattered_site & ESBedType!=2)) 

--- a/changelog.R
+++ b/changelog.R
@@ -2,13 +2,14 @@ output$changelog <- renderDT({
   tribble(
     ~ Date,
     ~ Change,
-    "1-23-2024",
+    "1-30-2024",
     "<b>New Features</b> <br>
       - Added client-level export to the System Performance tab to provide transparency
       in the charts<br>
      <b>Bug Fixes:</b> <br>
       - Fixed display of missing geography and address warnings for PDDE.<br>
       - Only flag residential projects for Active Inventory PDDE check.<br>
+      - Only reference active inventory records to check bed type compatibility with housing type.<br>
       - Fixed edge case detection of NbN overlaps; i.e., too many duplicates caused a join error and crashed Eva.<br>
       - Fixed issue in how the Age and Race filter selections are displayed in the System Exports.",
     "12-31-2024",


### PR DESCRIPTION
Reference active inventory records instead of all inventory records to check bed type compatibility with housing type. Addresses issue 680: https://github.com/abtassociates/eva/issues/680