### PR TITLE
move the logMetadata call that tracks System Overview-related Data Downloads...

### DIFF
--- a/system_composition_server.R
+++ b/system_composition_server.R
@@ -664,6 +664,8 @@ output$sys_comp_download_btn <- downloadHandler(
       col_names = TRUE
     )
     
+    logMetadata(paste0("Downloaded System Overview Tabular Data: ", input$syso_tabbox,
+                       if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))
     exportTestValues(sys_comp_report_num_df = num_df)
     exportTestValues(sys_comp_report_pct_df = pct_df)
   }

--- a/system_inflow_outflow_server.R
+++ b/system_inflow_outflow_server.R
@@ -388,10 +388,8 @@ output$sys_inflow_outflow_download_btn <- downloadHandler(
       col_names = TRUE
     )
     
-    logMetadata(paste0(
-      "Downloaded Sys Inflow Outflow Report",
-      if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")
-    ))
+    logMetadata(paste0("Downloaded System Overview Tabular Data: ", input$syso_tabbox,
+                       if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))
     exportTestValues(sys_inflow_outflow_report = summarize_df(sys_inflow_outflow_plot_data()))
   }
 )

--- a/system_overview_server.R
+++ b/system_overview_server.R
@@ -172,9 +172,6 @@ toggle_sys_components(FALSE, init=TRUE) # initially hide them
 
 sys_export_summary_initial_df <- function() {
   
-  logMetadata(paste0("Downloaded System Overview Tabular Data: ", input$syso_tabbox,
-                     if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))
-  
   return(data.frame(
     Chart = c(
       "Start Date",

--- a/system_status_server.R
+++ b/system_status_server.R
@@ -190,7 +190,9 @@ output$sys_status_download_btn <- downloadHandler(
       format_headers = FALSE,
       col_names = TRUE
     )
-
+    
+    logMetadata(paste0("Downloaded System Overview Tabular Data: ", input$syso_tabbox,
+                       if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))
     exportTestValues(sys_status_report = sankey_plot_data())
   }
 )


### PR DESCRIPTION
... from the sys_export_summary_initial_df - which is called in a number of places, including the PPT downloads, and therefore we're overcounting tabular downloads - to within the download handler of the specific Data Download. This is more intuitive and doesn't overcount downloads