### PR TITLE
use lubridate::dyears instead of lubridate::years because the former …

### DIFF
--- a/07_system_overview.R
+++ b/07_system_overview.R
@@ -390,7 +390,7 @@ enrollment_categories <- as.data.table(enrollment_prep_hohs)[, `:=`(
     in_date_range = ExitAdjust >= ReportStart() & EntryDate <= ReportEnd()
   )][
     # Apply filtering with efficient conditions
-    (ReportStart() - years(2)) <= ExitAdjust &
+    (ReportStart() - lubridate::dyears(2)) <= ExitAdjust &
       ProjectType != hp_project_type &
       (ProjectType != ce_project_type |
          (ProjectType == ce_project_type &


### PR DESCRIPTION
…counts years in days, rather than just subtracting the number from the year value, which fails for leap years if the number is not 4, since, e.g. 2 years prior to a leap year doesn't contain a 02-29 date.