### PR TITLE
Hotfix/dq

### DIFF
--- a/05_DataQuality_functions.R
+++ b/05_DataQuality_functions.R
@@ -180,14 +180,17 @@ getDQReportDataList <-
 
 calculate_long_stayers_local_settings_dt <- function(too_many_days, projecttype){
   # get non-exited enrollments for projecttype
+  logToConsole(glue("In calculate long stayers: too_many_days = {too_many_days}, projecttype = {projecttype}"))
   non_exits <- validation() %>%
     fsubset(ProjectType == projecttype & 
              (ExitDate >= meta_HUDCSV_Export_End() | is.na(ExitDate))
     ) %>%
     fselect(vars_prep)
   
+  
   # only proceed if there are any non-exited enrollments
   if(nrow(non_exits) == 0) return(NULL)
+  logToConsole("Has non-exits")
   
   # data with last-known dates
   # we're going to later compute the LAST Known Date to determine when we last heard from them
@@ -215,7 +218,7 @@ calculate_long_stayers_local_settings_dt <- function(too_many_days, projecttype)
       # Take EntryDate if there's no Information or DateProvided
       fmutate(LastKnown = fcoalesce(fmax(KnownDate), EntryDate))
   }
-  
+  logToConsole("calculating long_stayres")
   # calculate days since last known
   long_stayers <- qDT(non_exits_w_lastknown_date) %>%
     fmutate(
@@ -228,6 +231,7 @@ calculate_long_stayers_local_settings_dt <- function(too_many_days, projecttype)
   
   if(nrow(long_stayers) == 0) return(NULL)
   
+  logToConsole("merging check info")
   # Each project type gets its own Issue text+Guidance etc.
   merge_check_info_dt(
     long_stayers,
@@ -418,9 +422,11 @@ dqDownloadInfo <- reactive({
   exportTestValues(dq_overlaps = overlap_details() %>% nice_names())
   
   # org-level data prep (filtering to selected org)
+  logToConsole(glue("About to filter dq_main_reactive nrows(dq_main_reactive) = {nrow(dq_main_reactive())}"))
   orgDQData <- dq_main_reactive() %>%
     filter(OrganizationName %in% c(input$orgList))
   
+  logToConsole(glue("About to filter overlap_details. nrows(overlap) = {nrow(overlap_details())}"))
   orgDQoverlapDetails <- overlap_details() %>% 
     filter(OrganizationName %in% c(input$orgList) | 
              PreviousOrganizationName %in% c(input$orgList))

--- a/05_DataQuality_functions.R
+++ b/05_DataQuality_functions.R
@@ -423,11 +423,11 @@ dqDownloadInfo <- reactive({
   exportTestValues(dq_overlaps = overlap_details() %>% nice_names())
   
   # org-level data prep (filtering to selected org)
-  logToConsole(glue("About to filter dq_main_reactive nrows(dq_main_reactive) = {nrow(dq_main_reactive())}"))
+  logToConsole("About to filter dq_main_reactive")
   orgDQData <- dq_main_reactive() %>%
     filter(OrganizationName %in% c(input$orgList))
   
-  logToConsole(glue("About to filter overlap_details. nrows(overlap) = {nrow(overlap_details())}"))
+  logToConsole("About to filter overlap_details")
   orgDQoverlapDetails <- overlap_details() %>% 
     filter(OrganizationName %in% c(input$orgList) | 
              PreviousOrganizationName %in% c(input$orgList))

--- a/05_DataQuality_functions.R
+++ b/05_DataQuality_functions.R
@@ -203,14 +203,15 @@ calculate_long_stayers_local_settings_dt <- function(too_many_days, projecttype)
     services() %>% fselect(EnrollmentID, KnownDate = DateProvided)
   } else {
     # If a different project type, we'll just use their EntryDate as the KnownDate
-    non_exits %>% fselect(vars_prep, KnownDate = EntryDate)
+    non_exits
   }
   
   # calculate last-known date (differs by project type)
   if(projecttype %in% c(other_project_project_type, day_project_type)) {
     # LastKnown = KnownDate (not fmax) because it's per enrollment, and EntryDate (now KnownDate) is at Enrollment level
     non_exits_w_lastknown_date <- data_w_dates %>%
-      fselect(vars_prep, LastKnown = KnownDate)
+      fselect(vars_prep) %>% 
+      frename(LastKnown = EntryDate)
   } else {
     non_exits_w_lastknown_date <- 
       join(non_exits, data_w_dates, on = "EnrollmentID", how="left") %>%

--- a/07_system_overview.R
+++ b/07_system_overview.R
@@ -931,8 +931,8 @@ universe <- reactive({
         (straddles_start == TRUE |
            (straddles_start == FALSE &
               EntryDate >= ReportStart() &
-              between(difftime(EntryDate, ReportStart(),
-                               units = "days"),
+              between(as.integer(difftime(EntryDate, ReportStart(),
+                               units = "days")),
                       0,
                       14) &
               !is.na(days_since_previous_exit) &

--- a/tests/testing_functions.R
+++ b/tests/testing_functions.R
@@ -452,7 +452,7 @@ main_test_script <- function(test_script_name, test_dataset) {
 
 
 # This is equivalent to snapshot_review(), but for the helper csv files
-get_all_helper_filenames <- function() {
+get_all_helper_filenames <- function(test_script_name) {
   helper_data_dir <- glue(here("tests/helper_data/{gsub('test-','', test_script_name)}"))
   all_files <- basename(list.files(helper_data_dir))
   new_files <- grep(pattern = "\\.new\\.", x = all_files, value = TRUE)
@@ -460,7 +460,7 @@ get_all_helper_filenames <- function() {
 }
 review_helpers <- function(datasetnames = NULL, test_script_name = "main-valid", comparison_type = 1) {
   if(is.null(datasetnames)) 
-    datasetnames <- get_all_helper_filenames()
+    datasetnames <- get_all_helper_filenames(test_script_name)
 
   for(datasetname in datasetnames) {
     review_helper(datasetname, test_script_name, comparison_type)

--- a/tests/testing_functions.R
+++ b/tests/testing_functions.R
@@ -507,7 +507,7 @@ records_in_one_or_another <- function(old, new, datasetname) {
 # This is equivalent to snapshot_accept(), but for the helper csv files
 accept_helpers <- function(datasetnames = NULL, test_script_name = "main-valid") {
   if(is.null(datasetnames)) 
-    datasetnames <- get_all_helper_filenames()
+    datasetnames <- get_all_helper_filenames(test_script_name)
   
   for(datasetname in datasetnames) {
     accept_helper(datasetname, test_script_name)


### PR DESCRIPTION
- fix bug where we're selecting a character vector of variables (vars_prep) AND renaming a variable in calculate_long_stayers_settings_dt. Now, splitting them out