### PR TITLE
Hotfix for PDDE 0-row error

### DIFF
--- a/06_PDDE_Checker.R
+++ b/06_PDDE_Checker.R
@@ -489,7 +489,9 @@ nbn_nobns <- nbn_w_hmis_participation %>% # Get enrollments whose projects were 
   join(services_chk, on = "EnrollmentID", how = "left") %>%
   fgroup_by(ProjectID) %>%
   fmutate(
-    miss_all_enroll = all(is.na(has_bn_eq_entry)) # not having this value implies EnrollmentID NOT in services_check
+    # not having this value implies EnrollmentID NOT in services_check
+    # added check that there more than 0 rows; if not, was throwing a NULL error
+    miss_all_enroll = fifelse(GRPN() > 0, all(is.na(has_bn_eq_entry)), logical(0))
   ) %>% fungroup()
 
 rm(nbn_w_hmis_participation, services_chk)


### PR DESCRIPTION
Demo mode was getting an error with previous branch/merges. It stopped in 06_PDDE_checker.R for an issue with a data.table having 0 rows. Added a check that returns `logical(0)` for that case.

