### PR TITLE
living sitituation err should only check LivingSitutation column

### DIFF
--- a/05_DataQuality.R
+++ b/05_DataQuality.R
@@ -468,8 +468,6 @@ dkr_living_situation <- base_dq_data %>%
   fsubset((RelationshipToHoH == 1 | AgeAtEntry > 17) &
            EntryDate > hc_prior_living_situation_required &
            (
-             MonthsHomelessPastThreeYears %in% c(dkr_dnc) |
-               TimesHomelessPastThreeYears %in% c(dkr_dnc) |
                LivingSituation %in% c(dkr_dnc)
            )
   ) %>%


### PR DESCRIPTION
related to issue #925 

removes months/times homeless columns from the living situtation error (id=68). These are captured in dkr_months_times_homeless (id = 69)