### PR TITLE
Hotfix Client Counts download button

### DIFF
--- a/client_counts_server.R
+++ b/client_counts_server.R
@@ -131,7 +131,7 @@ pivot_and_sum <- function(df, isDateRange = FALSE) {
   return(pivoted)
 }
 
-get_clientcount_download_info <- function(file, orgList = unique(client_count_data_df()$OrganizationName),
+get_clientcount_download_info <- function(orgList = unique(client_count_data_df()$OrganizationName),
                                           dateRangeEnd = input$dateRangeCount[2]) {
   logToConsole(session, "in get_clientcount_download_info")
    client_counts_metadata <- data.table(
@@ -746,7 +746,7 @@ output$downloadClientCountsReportButton  <- renderUI({
 # just the current date.
 output$downloadClientCountsReport <- downloadHandler(
   filename = date_stamped_filename("System-level Project Dashboard Report-"),
-  content = {
+  content = function(file){
     logMetadata(session, paste0("Downloaded Project Dashboard Report with Date Range = [",
                                 paste0(input$dateRangeCount, collapse=', '),']',
                                 if_else(isTruthy(input$in_demo_mode), " - DEMO MODE", "")))

--- a/data_quality_server.R
+++ b/data_quality_server.R
@@ -1021,7 +1021,7 @@ output$dq_export_download_btn <- downloadHandler(
             dir.create(path_prefix)
           }
           proj_dash_filename <- date_stamped_filename(str_glue('{org_name_std} - Project Dashboard Report-'))
-          pd_org_export <- get_clientcount_download_info(file = file.path(tempdir(), str_glue(zip_prefix, proj_dash_filename)), 
+          pd_org_export <- get_clientcount_download_info( 
                                         orgList = i, dateRangeEnd = dq_export_date_range_end())
           if(length(pd_org_export) > 1){
             write_xlsx(pd_org_export, path = file.path(tempdir(), str_glue(zip_prefix, proj_dash_filename)))
@@ -1067,7 +1067,7 @@ output$dq_export_download_btn <- downloadHandler(
         
         proj_dash_filename <- date_stamped_filename('System-level Project Dashboard Report-')
         if(fnrow(client_count_data_df()) > 0){
-          pd_sys_export <- get_clientcount_download_info(file = file.path(path_prefix, proj_dash_filename), dateRangeEnd = dq_export_date_range_end())
+          pd_sys_export <- get_clientcount_download_info(dateRangeEnd = dq_export_date_range_end())
           if(length(pd_sys_export) > 1){
             write_xlsx(pd_sys_export, path = file.path(path_prefix, proj_dash_filename))
             zip_files <- c(zip_files, str_glue(zip_prefix, proj_dash_filename))


### PR DESCRIPTION
Remove file argument from get_clientcount_download_info, since writing to Excel is now done outside of this function. This arg was also missing in the downloadHandler and causied errors in the Client-level export download button