### PR TITLE
Hotfix/long stayers hoh check

### DIFF
--- a/05_DataQuality.R
+++ b/05_DataQuality.R
@@ -1716,7 +1716,7 @@ calculate_long_stayers_local_settings_dt <- function(projecttype){
   if(projecttype %in% c(out_project_type, sso_project_type, ce_project_type)){
     non_exits <- non_exits %>% 
       join(Enrollment %>% fselect(EnrollmentID,  PersonalID, RelationshipToHoH, AgeAtEntry), how='left', on='EnrollmentID') %>% 
-      fsubset(RelationshipToHoH == 1 | AgeAtEntry > 17)
+      fsubset(RelationshipToHoH == 1 | (!is.na(AgeAtEntry) & AgeAtEntry > 17))
   }
   
   # only proceed if there are any non-exited enrollments

--- a/05_DataQuality.R
+++ b/05_DataQuality.R
@@ -1712,6 +1712,13 @@ calculate_long_stayers_local_settings_dt <- function(projecttype){
     ) %>%
     fselect(vars_prep)
   
+  # remove non-HoHs and children for check 103
+  if(projecttype %in% c(out_project_type, sso_project_type, ce_project_type)){
+    non_exits <- non_exits %>% 
+      join(Enrollment %>% fselect(EnrollmentID,  PersonalID, RelationshipToHoH, AgeAtEntry), how='left', on='EnrollmentID') %>% 
+      fsubset(RelationshipToHoH == 1 | AgeAtEntry > 17)
+  }
+  
   # only proceed if there are any non-exited enrollments
   if(nrow(non_exits) == 0) return(NULL)
   logToConsole(session, "Has non-exits")

--- a/05_DataQuality.R
+++ b/05_DataQuality.R
@@ -1715,8 +1715,9 @@ calculate_long_stayers_local_settings_dt <- function(projecttype){
   # remove non-HoHs and children for check 103
   if(projecttype %in% c(out_project_type, sso_project_type, ce_project_type)){
     non_exits <- non_exits %>% 
-      join(Enrollment %>% fselect(EnrollmentID,  PersonalID, RelationshipToHoH, AgeAtEntry), how='left', on='EnrollmentID') %>% 
-      fsubset(RelationshipToHoH == 1 | (!is.na(AgeAtEntry) & AgeAtEntry > 17))
+      join(Enrollment %>% fselect(EnrollmentID,  PersonalID, RelationshipToHoH, AgeAtEntry), how='left', on=c('EnrollmentID','PersonalID')) %>% 
+      fsubset(RelationshipToHoH == 1 | (!is.na(AgeAtEntry) & AgeAtEntry > 17)) %>% 
+      fselect(-RelationshipToHoH, -AgeAtEntry)
   }
   
   # only proceed if there are any non-exited enrollments

--- a/changelog.R
+++ b/changelog.R
@@ -3,6 +3,10 @@ output$changelog <- renderDT({
   changelog_dt <- tribble(
     ~ Date,
     ~ Change,
+    "03-30-2026",
+    "<b>Bug Fixes</b> <br>
+      - Ignore non-HoH children in DQ check for Days Since Most Recent CLS for Street Outreach, Services Only, and Coordinated Entry projects. (Issue <a href='https://github.com/abtassociates/eva/issues/940' target='_blank'>#940</a>)
+    ",
     "02-24-2026",
     "<b>Bug Fixes</b> <br>
       - Corrected logic for refreshing DQ and PDDE tables and downloads when multiple datasets are uploaded within a session. (Issue <a href='https://github.com/abtassociates/eva/issues/963' target='_blank'>#963</a>)<br>

--- a/tests/testthat/_snaps/linux-4.5/main-valid/test-main-valid-dq-org.json
+++ b/tests/testthat/_snaps/linux-4.5/main-valid/test-main-valid-dq-org.json
@@ -883,7 +883,7 @@
       ]
     },
     "orgDQWarningByIssue": {
-      "src": "[image data hash: 5113bfaadcfbb767779a5aad9f85d9e4]",
+      "src": "[image data hash: 4afa65ac49d6b40bec4b085421a8fcd6]",
       "width": 1640,
       "height": 400,
       "alt": "A bar chart of the top Warnings in the organization.",
@@ -960,7 +960,7 @@
       ]
     },
     "orgDQWarningByProject": {
-      "src": "[image data hash: 3c6eb2cb4095b6fe435e869a27e1a518]",
+      "src": "[image data hash: 07baba30a07569e4b97a2f84a49519bb]",
       "width": 1640,
       "height": 400,
       "alt": "A bar chart of the organization's projects with the most Warnings.",
@@ -992,8 +992,8 @@
                   "Organization A - RRH",
                   "Organization A - HP",
                   "Organization A - HP - 2",
-                  "Organization A - RRH - 2",
                   "Organization A - SO",
+                  "Organization A - RRH - 2",
                   "Organization A - ES - 2",
                   "Organization A - ES"
                 ]

--- a/tests/testthat/_snaps/linux-4.5/main-valid/test-main-valid-dq-system.json
+++ b/tests/testthat/_snaps/linux-4.5/main-valid/test-main-valid-dq-system.json
@@ -191,7 +191,7 @@
       ]
     },
     "sysDQWarningByIssue": {
-      "src": "[image data hash: 08a9d7441b38edd41ead22ac9eaa19d5]",
+      "src": "[image data hash: 29ed27cf4d5beebcc33b2b8a9c2369cf]",
       "width": 1640,
       "height": 400,
       "alt": "A bar chart of the top Warnings in the system.",

--- a/tests/testthat/_snaps/linux-4.5/main-valid/test-main-valid-exportTestValues.json
+++ b/tests/testthat/_snaps/linux-4.5/main-valid/test-main-valid-exportTestValues.json
@@ -532,7 +532,7 @@
         ],
         [
           null,
-          "Mean   : 23.89  ",
+          "Mean   : 23.47  ",
           null
         ],
         [
@@ -569,7 +569,7 @@
           null,
           null,
           null,
-          "Mean   :  9.034  "
+          "Mean   :  8.874  "
         ],
         [
           null,
@@ -739,14 +739,14 @@
       ],
       "Warnings": [
         [
-          "Length:822        ",
-          "Length:822        ",
-          "Length:822        ",
-          "Length:822        ",
-          "Length:822        ",
-          "Length:822        ",
-          "Length:822        ",
-          "Length:822        ",
+          "Length:803        ",
+          "Length:803        ",
+          "Length:803        ",
+          "Length:803        ",
+          "Length:803        ",
+          "Length:803        ",
+          "Length:803        ",
+          "Length:803        ",
           "Min.   :2019-08-17  "
         ],
         [
@@ -758,7 +758,7 @@
           "Class :character  ",
           "Class :character  ",
           "Class :character  ",
-          "1st Qu.:2020-11-03  "
+          "1st Qu.:2020-11-02  "
         ],
         [
           "Mode  :character  ",
@@ -769,7 +769,7 @@
           "Mode  :character  ",
           "Mode  :character  ",
           "Mode  :character  ",
-          "Median :2021-08-08  "
+          "Median :2021-07-27  "
         ],
         [
           null,
@@ -780,7 +780,7 @@
           null,
           null,
           null,
-          "Mean   :2021-07-09  "
+          "Mean   :2021-06-30  "
         ],
         [
           null,
@@ -791,7 +791,7 @@
           null,
           null,
           null,
-          "3rd Qu.:2022-03-24  "
+          "3rd Qu.:2022-03-07  "
         ],
         [
           null,
@@ -1488,7 +1488,7 @@
         ],
         [
           null,
-          "Mean   :  830.0  ",
+          "Mean   :  799.9  ",
           null
         ],
         [
@@ -1507,37 +1507,37 @@
           "Length:996        ",
           "High Priority: 56  ",
           "Length:996        ",
-          "Min.   :   1  "
+          "Min.   :   1.00  "
         ],
         [
           "Class :character  ",
           "Error        :442  ",
           "Class :character  ",
-          "1st Qu.:   3  "
+          "1st Qu.:   3.00  "
         ],
         [
           "Mode  :character  ",
           "Warning      :498  ",
           "Mode  :character  ",
-          "Median :   8  "
+          "Median :   8.00  "
         ],
         [
           null,
           null,
           null,
-          "Mean   :  60  "
+          "Mean   :  57.82  "
         ],
         [
           null,
           null,
           null,
-          "3rd Qu.:  25  "
+          "3rd Qu.:  25.00  "
         ],
         [
           null,
           null,
           null,
-          "Max.   :5367  "
+          "Max.   :5367.00  "
         ]
       ],
       "Guidance": [
@@ -1695,14 +1695,14 @@
       ],
       "Warnings": [
         [
-          "Length:46050      ",
-          "Length:46050      ",
-          "Length:46050      ",
-          "Length:46050      ",
-          "Length:46050      ",
-          "Length:46050      ",
-          "Length:46050      ",
-          "Length:46050      ",
+          "Length:43883      ",
+          "Length:43883      ",
+          "Length:43883      ",
+          "Length:43883      ",
+          "Length:43883      ",
+          "Length:43883      ",
+          "Length:43883      ",
+          "Length:43883      ",
           "Min.   :2005-04-14  "
         ],
         [
@@ -1714,7 +1714,7 @@
           "Class :character  ",
           "Class :character  ",
           "Class :character  ",
-          "1st Qu.:2020-06-11  "
+          "1st Qu.:2020-06-12  "
         ],
         [
           "Mode  :character  ",
@@ -1725,7 +1725,7 @@
           "Mode  :character  ",
           "Mode  :character  ",
           "Mode  :character  ",
-          "Median :2021-03-02  "
+          "Median :2021-02-25  "
         ],
         [
           null,
@@ -1736,7 +1736,7 @@
           null,
           null,
           null,
-          "Mean   :2021-02-14  "
+          "Mean   :2021-02-15  "
         ],
         [
           null,
@@ -1747,7 +1747,7 @@
           null,
           null,
           null,
-          "3rd Qu.:2022-01-07  "
+          "3rd Qu.:2021-12-27  "
         ],
         [
           null,


### PR DESCRIPTION
For DQ check 103, ignore non-HoH children and only check for adults / HoHs.

Should address bug mentioned in #940.