### PR TITLE
Hotfix/fix missing dest updates

### DIFF
--- a/helper_functions.R
+++ b/helper_functions.R
@@ -15,7 +15,7 @@ fix_missing_destination <- function(ReferenceNo, Detail = NULL){
       is.na(ReferenceNo) & Detail == 'Exited, Non-Permanent', 99L,
       is.na(ReferenceNo) & Detail == 'Inactive', -888L,
       !is.na(ReferenceNo) & (ReferenceNo %in% perm_livingsituation) & Detail == 'Inactive', -888L,
-      default = ReferenceNo
+      default = as.integer(ReferenceNo)
     )
   } 
   

--- a/helper_functions.R
+++ b/helper_functions.R
@@ -12,9 +12,9 @@ age_years <- function(earlier, later)
 fix_missing_destination <- function(ReferenceNo, Detail = NULL){
   if(!missing(Detail)){
     ReferenceNo <- fcase(
-      is.na(ReferenceNo) & Detail == 'Exited, Non-Permanent', 99,
-      is.na(ReferenceNo) & Detail == 'Inactive', -888,
-      !is.na(ReferenceNo) & (ReferenceNo %in% perm_livingsituation) & Detail == 'Inactive', -888,
+      is.na(ReferenceNo) & Detail == 'Exited, Non-Permanent', 99L,
+      is.na(ReferenceNo) & Detail == 'Inactive', -888L,
+      !is.na(ReferenceNo) & (ReferenceNo %in% perm_livingsituation) & Detail == 'Inactive', -888L,
       default = ReferenceNo
     )
   } 


### PR DESCRIPTION
fix bug flagged by shinytest where ReferenceNo is not the same type as the hardcoded fixes, causing the `fcase` in `fix_missing_destination` to crash the app.